### PR TITLE
chore: add docker build ci

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,25 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: cherrypush/cherry:latest

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   docker:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   docker:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# Getting started
+# Cherry
+
+## Getting started
 
 ```sh
 # clone the project
-git clone git@github.com:cherrypush/cherry-app.git
-cd cherry-app
+git clone git@github.com:cherrypush/cherry.git
+cd cherry
 
 # install dependencies
 bundle install
@@ -38,4 +40,21 @@ Finally, you can launch your server with:
 
 ```sh
 bin/dev
+```
+
+## Running in Production
+
+The current stack is :
+- a PostgreSQL database
+- the cherry app itself
+
+### Using Docker
+
+Use the `cherrypush/cherry` image. You will need a running instance of Postgres.
+
+```
+docker run \
+  -e SECRET_KEY_BASE=<secret> \
+  -e DATABASE_URL=postgresql://<user>:<pass>@<host>:5432/<db_name> \
+  cherrypush/cherry
 ```


### PR DESCRIPTION
Ahoy 👋 

The goal here is to allow any Docker user to pull the latest version of cherry and start their own instance in a few minutes!

This will build and push a new image from the main branch and tag it as cherrypush/cherry:latest on every push on this branch!

You would need to create the corresponding docker account and setup the user/pass pair in this repo's secrets. See: https://docs.docker.com/build/ci/github-actions/