### PR TITLE
chore(deps): fix critical axios SSRF vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@tanstack/react-query-devtools": "^4.33.0",
         "@tanstack/react-table": "^8.20.5",
         "apexcharts": "^3.49.1",
-        "axios": "^1.12.2",
+        "axios": "^1.15.0",
         "classnames": "^2.3.2",
         "flowbite": "^2.5.2",
         "flowbite-react": "^0.7.0",
@@ -2541,9 +2541,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@tanstack/react-query-devtools": "^4.33.0",
     "@tanstack/react-table": "^8.20.5",
     "apexcharts": "^3.49.1",
-    "axios": "^1.12.2",
+    "axios": "^1.15.0",
     "classnames": "^2.3.2",
     "flowbite": "^2.5.2",
     "flowbite-react": "^0.7.0",


### PR DESCRIPTION
## Summary
- Bumps `axios` from 1.14.0 to 1.15.0 to fix two critical SSRF vulnerabilities
- [GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5): NO_PROXY hostname normalization bypass
- [GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx): cloud metadata exfiltration via header injection

## Test plan
- [ ] Verify app loads and API calls work correctly
- [ ] Confirm `npm audit` no longer reports critical vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)