### PR TITLE
fix(deps): pin connection_pool to 2.x to fix deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '3.3.8'
 
 # default gems
 gem 'bootsnap', require: false
+gem 'connection_pool', '~> 2.4' # pin to 2.x; 3.0+ breaks Rails 7.2 redis_cache_store
 gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
 gem 'rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     chartkick (5.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crass (1.0.6)
     csv (3.3.0)
     date (3.5.1)
@@ -410,6 +410,7 @@ DEPENDENCIES
   blazer
   bootsnap
   capybara
+  connection_pool (~> 2.4)
   debug
   delayed_job_active_record
   dockerfile-rails


### PR DESCRIPTION
## Summary
- Pins `connection_pool` to `~> 2.4` (downgrades from 3.0.2 to 2.5.5)
- Fixes Heroku deploy failure caused by `connection_pool` 3.0 changing its `initialize` signature, which is incompatible with Rails 7.2's `redis_cache_store`

## Test plan
- [ ] Verify Heroku build succeeds (asset precompilation no longer crashes)
- [ ] Confirm Redis caching works in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)