### PR TITLE
Add Umami analytics (production only)

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -8,3 +8,7 @@
 <%= vite_typescript_tag 'application.tsx' %>
 <%= stylesheet_link_tag 'application', 'inter-font' %>
 <%= stylesheet_link_tag 'tailwind', 'inter-font' %>
+
+<% if Rails.env.production? %>
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="b239e429-b257-4b52-a6cf-4b9a8bd3a8c6"></script>
+<% end %>


### PR DESCRIPTION
## Summary
- Adds Umami cloud analytics script to the `<head>` partial
- Wrapped in `Rails.env.production?` so it only loads in production

## Test plan
- [ ] Verify script tag is present in page source in production
- [ ] Verify script tag is absent in development

🤖 Generated with [Claude Code](https://claude.com/claude-code)