### PR TITLE
Fix PG deadlock in Api::PushesController (CHERRY-RAILS-6Q)

### DIFF
--- a/app/controllers/api/pushes_controller.rb
+++ b/app/controllers/api/pushes_controller.rb
@@ -34,6 +34,8 @@ class Api::PushesController < Api::ApplicationController
             end
           )
         end
+
+      current_project.touch
     end
 
     render json: { status: :ok }, status: :created

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,10 +3,7 @@
 class Report < ApplicationRecord
   belongs_to :metric
 
-  after_save do
-    metric.touch
-    metric.project.touch
-  end
+  after_save { metric.touch }
 
   has_many :occurrences, dependent: :destroy
 

--- a/test/controllers/api/pushes_controller_test.rb
+++ b/test/controllers/api/pushes_controller_test.rb
@@ -168,6 +168,12 @@ class Api::PushesControllerTest < ActionDispatch::IntegrationTest
       assert_equal 24, metric_with_value.reports.last.value
     end
 
+    it 'bumps project.updated_at after a push' do
+      create(:project, name: 'cherrypush/cherry-app', user: user, updated_at: 1.week.ago)
+      post(api_push_path, params: { api_key: user.api_key, **payload }, as: :json)
+      assert_equal Date.current, Project.sole.reload.updated_at.to_date
+    end
+
     it 'adds up value_by_owner to existing value_by_owner by uuid' do
       post(api_push_path, params: { api_key: user.api_key, **payload }, as: :json)
       metric_with_owners = Metric.find_by(name: 'missing coverage')

--- a/test/models/metric_test.rb
+++ b/test/models/metric_test.rb
@@ -11,7 +11,6 @@ class ProjectTest < ActiveSupport::TestCase
     it 'updates the updated_at field when a new report is created' do
       create(:report, metric: metric)
       assert_equal Time.current.to_date, metric.reload.updated_at.to_date
-      assert_equal Time.current.to_date, project.reload.updated_at.to_date
     end
   end
 
@@ -37,11 +36,6 @@ class ProjectTest < ActiveSupport::TestCase
     it 'does not update project updated_at field when deleting a metric' do
       metric.destroy!
       assert_equal 1.week.ago.to_date, project.reload.updated_at.to_date
-    end
-
-    it 'updates the project updated_at field when creating a report for an existing metric' do
-      create(:report, metric: metric)
-      assert_equal Date.current, project.reload.updated_at.to_date
     end
   end
 


### PR DESCRIPTION
## Summary

- Sentry issue [CHERRY-RAILS-6Q](https://cherrypush.sentry.io/issues/CHERRY-RAILS-6Q) reports `PG::TRDeadlockDetected` on the `projects` table from `Api::PushesController#create` under concurrent pushes.
- Root cause: `Report`'s `after_save` called `metric.project.touch`, so a push with N metrics issued N UPDATEs on the same `projects` row inside one transaction. Two concurrent pushes interleaved their lock acquisitions → deadlock.
- Fix: remove `metric.project.touch` from the Report callback and touch the project **once** at the end of the push transaction in the controller. One UPDATE per push instead of N.

## Test plan

- [x] `bin/rails test test/models/metric_test.rb test/controllers/api/pushes_controller_test.rb` passes (19 runs, 60 assertions, 0 failures)
- [x] Added `'bumps project.updated_at after a push'` test in `pushes_controller_test.rb`
- [x] Removed the now-obsolete model-level `project.updated_at` assertions
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)