### PR TITLE
Pin Node engine to 20.x (for Heroku-24 stack upgrade)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "type": "module",
   "version": "0.0.0",
   "private": true,
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "build": "vite build --outDir public"
   },


### PR DESCRIPTION
## Summary
- Pins Node engine to `20.x` in `package.json` ahead of the Heroku stack upgrade from `heroku-22` to `heroku-24` (already set via `heroku stack:set heroku-24`).
- Heroku-24 defaults differ from heroku-22, so an explicit pin avoids surprises on the first deploy.
- Follow-up to bump to Node 22 (active LTS) tracked in #621.

## Test plan
- [ ] Merge, deploy, verify build succeeds on heroku-24 with Node 20.x